### PR TITLE
chore(test): Allow testing on Python 3.5 and 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,16 @@ setup(
     author_email='support@storyscript.io',
     url='https://github.com/storyscript/hub-sdk-python',
     packages=find_packages(exclude=('tests', 'docs')),
+    python_requires='>=3.5',
     install_requires=[
         'requests~=2.21',
         'peewee==3.9.3',
         'cachetools==3.1.0'
     ],
     tests_require=[
-        'pytest==4.3.1',
-        'pytest-mock==1.10.2',
-        'pytest-cov==2.6.1'
+        'pytest',
+        'pytest-mock',
+        'pytest-cov'
     ],
     setup_requires=['pytest-runner==4.4']
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,25 @@
 [tox]
-envlist = py36,pep8
+minversion = 1.6
+envlist = py35,py36,py37,pep8
+skip_missing_interpreters = true
 
 
-[testenv:py36]
+[testenv]
 passenv = DOCKER_HOST DOCKER_MACHINE_NAME DOCKER_TLS_VERIFY DOCKER_CERT_PATH
 
 deps =
-    pytest==4.3.1
-    pytest-mock==1.10.2
-    pytest-cov==2.6.1
+    pytest
+    pytest-mock
+    pytest-cov
 
 commands =
-    pytest --cov=. --cov-report=term-missing {posargs}
+    pytest --cov=storyhub --cov-report=term-missing {posargs}
     coverage xml
 
 
 [testenv:pep8]
-whitelist_externals = coverage
+usedevelop = true
+skip_install = true
 deps =
     flake8==3.5.0
     flake8-quotes==1.0.0


### PR DESCRIPTION
Python 3.5 is the minimum required version of storyscript,
which depends on story-hub.

Add py35 and py37 to tox envlist, and removes test deps pins
as the appropriate versions for each Python version should
be determined by the pytest packaging as these are very
well maintained plugins.

Also limit coverage reports to the current module,
removing everything in .tox from the reports.

And do not install library and deps into pep8 test environment.