### PR TITLE
fix(OutputProperty): return type correctly

### DIFF
--- a/storyhub/sdk/service/OutputProperty.py
+++ b/storyhub/sdk/service/OutputProperty.py
@@ -3,7 +3,7 @@ from storyhub.sdk.service.ServiceObject import ServiceObject
 
 class OutputProperty(ServiceObject):
     """
-    A service output action
+    A service output Property.
     """
 
     def __init__(self, name, type_, help_, data):
@@ -33,5 +33,5 @@ class OutputProperty(ServiceObject):
     def help(self):
         return self._help_
 
-    def type(self, name):
-        return self._type.get(name, None)
+    def type(self):
+        return self._type

--- a/tests/storyhub/sdk/service/OutputProperty_test.py
+++ b/tests/storyhub/sdk/service/OutputProperty_test.py
@@ -26,3 +26,13 @@ def test_serialization(mocker):
 
     assert service_event.as_json() is not None
     json.dumps.assert_called_with(output_property_fixture, indent=4, sort_keys=True)
+
+
+def test_getters(mocker):
+
+    property = OutputProperty.from_json(jsonstr=output_property_fixture_json)
+
+    assert property.type() == \
+        output_property_fixture['output_property']['type']
+
+    assert property.name() == output_property_fixture["name"]


### PR DESCRIPTION
Fixes the OutputProperty getter `type` to work correctly. Its seemed like a copy paste error was present in this codepath