### PR TITLE
always wrap JSON in service objects before returning

### DIFF
--- a/storyhub/sdk/ServiceWrapper.py
+++ b/storyhub/sdk/ServiceWrapper.py
@@ -103,6 +103,10 @@ class ServiceWrapper:
         return service_names
 
     def get(self, alias=None, owner=None, name=None):
+        if alias is not None and alias.count("/") == 1:
+            owner, name = alias.split("/")
+            alias = None
+
         service = None
 
         if alias and alias in self.services:

--- a/storyhub/sdk/StoryscriptHub.py
+++ b/storyhub/sdk/StoryscriptHub.py
@@ -91,7 +91,8 @@ class StoryscriptHub:
         :param alias: Takes precedence when specified over owner/name
         :param owner: The owner of the service
         :param name: The name of the service
-        :return: Returns a @ServiceData object instance.
+        :return: Returns a :py:class:~.sdk.service.ServiceData.ServiceData
+        object instance.
         """
 
         service = None

--- a/storyhub/sdk/service/Contact.py
+++ b/storyhub/sdk/service/Contact.py
@@ -3,7 +3,8 @@ from storyhub.sdk.service.ServiceObject import ServiceObject
 
 class Contact(ServiceObject):
     """
-    This represents contact info contained within @ServiceInfo
+    This represents contact info contained within
+    :py:class:~.sdk.service.ServiceData.ServiceInfo
     """
     def __init__(self, url, name, email, data):
         super().__init__(data)

--- a/storyhub/sdk/service/Service.py
+++ b/storyhub/sdk/service/Service.py
@@ -53,3 +53,6 @@ class Service(ServiceObject):
 
     def public(self):
         return self._public
+
+    def topics(self):
+        return self._topics


### PR DESCRIPTION
This drops the possibility of getting a raw JSON hub response.

Fixes: #41, #23 